### PR TITLE
Add clippy check to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 
+  check-clippy:
+    name: "Check with Clippy"
+    uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request_target'
+        with:
+          components: clippy
+      - name: Check with Clippy
+        run: cargo clippy --tests -- -D warnings
+
   ####### Building and Testing binaries #######
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,15 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
 
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-10-03
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          default: true
+
       - name: Check with Clippy
         run: cargo clippy --workspace --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,17 +108,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: rustup component add clippy
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          default: true
+        run: rustup component add clippy
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-12-15
+          toolchain: nightly
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
           default: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 
-  check-clippy:
-    name: "Check with Clippy"
+  check-rustfmt:
+    name: "Check with rustfmt"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -113,8 +113,8 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
 
-      - name: Check with Clippy
-        run: cargo clippy --tests -- -D warnings
+      - name: Check with rustfmt
+        run: cargo fmt
 
   ####### Building and Testing binaries #######
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
-          components: clippy
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - name: Checkout
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v2
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,15 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
 
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-10-03
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+          default: true
+
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           default: true
 
       - name: Check with Clippy
-        run: cargo clippy --tests -- -D warnings
+        run: cargo clippy --workspace --tests -- -D warnings
 
   ####### Building and Testing binaries #######
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,6 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
-        run: rustup component add clippy
 
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,10 @@ jobs:
 
   check-clippy:
     name: "Check with Clippy"
-    uses: actions/checkout@v2
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
         with:
           components: clippy
       - name: Check with Clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,15 +113,6 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2020-10-03
-          components: clippy, rustfmt
-          target: wasm32-unknown-unknown
-          default: true
-
       - name: Check with Clippy
         run: cargo clippy --workspace --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-12-15
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          default: true
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,6 @@ jobs:
     name: "Check with Clippy"
     runs-on: ubuntu-latest
     steps:
-      - run: rustup component add clippy
-
       - name: Checkout
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,17 +102,20 @@ jobs:
     name: "Check with Clippy"
     runs-on: ubuntu-latest
     steps:
+      - run: rustup component add clippy
+
       - name: Checkout
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: rustup component add clippy
+
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
         run: rustup component add clippy
+
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         # run: cargo clippy --workspace --tests -- -D warnings
 
       - name: Format code with rustfmt
-        run: cargo fmt --check
+        run: cargo fmt -- --check
 
   ####### Building and Testing binaries #######
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 
   check-clippy:
-    name: "Check with Clippy"
+    name: "Code checks"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -122,8 +122,11 @@ jobs:
           target: wasm32-unknown-unknown
           default: true
 
-      - name: Check with Clippy
-        run: cargo clippy --workspace --tests -- -D warnings
+          # - name: Check with Clippy
+        # run: cargo clippy --workspace --tests -- -D warnings
+
+      - name: Format code with rustfmt
+        run: cargo fmt --check
 
   ####### Building and Testing binaries #######
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
 
   check-clippy:
     name: "Check with Clippy"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,14 +95,6 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2020-12-15
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
-          default: true
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 
@@ -119,6 +111,14 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-12-15
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+          default: true
       - name: Check with Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .gitignore  '**/*.(yml|js|ts|json)'
 
-  check-rustfmt:
-    name: "Check with rustfmt"
+  check-clippy:
+    name: "Check with Clippy"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -113,8 +113,8 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
 
-      - name: Check with rustfmt
-        run: cargo fmt
+      - name: Check with Clippy
+        run: cargo clippy --tests -- -D warnings
 
   ####### Building and Testing binaries #######
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "cumulus-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "cumulus-consensus",
  "cumulus-network",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "cumulus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "futures 0.3.8",
  "log",
@@ -1089,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "cumulus-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "cumulus-primitives",
  "derive_more 0.99.11",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "cumulus-parachain-upgrade"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "cumulus-primitives",
  "cumulus-runtime",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "cumulus-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "cumulus-primitives",
  "frame-executive",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "cumulus-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#f327cd96dcd6a245aff150f48966ac0aff0ad509"
+source = "git+https://github.com/paritytech/cumulus#f327cd96dcd6a245aff150f48966ac0aff0ad509"
 dependencies = [
  "cumulus-collator",
  "cumulus-consensus",
@@ -1780,7 +1780,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4400,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4430,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4622,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4652,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 15.1.0",
@@ -4826,7 +4826,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5325,7 +5325,7 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -5359,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "frame-benchmarking-cli",
  "log",
@@ -5379,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-network-protocol",
@@ -5394,7 +5394,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -5418,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "async-trait",
  "futures 0.3.8",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-erasure-coding",
@@ -5452,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "futures 0.3.8",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-subsystem",
@@ -5508,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-subsystem",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-subsystem",
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-proposer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "futures 0.3.8",
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-subsystem",
@@ -5609,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -5620,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -5633,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "async-trait",
  "futures 0.3.8",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "async-trait",
  "futures 0.3.8",
@@ -5699,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.8",
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "polkadot-pov-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "polkadot-node-network-protocol",
@@ -5737,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "pallet-transaction-payment-rpc",
@@ -5792,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -5855,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-support",
@@ -5890,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "derive_more 0.99.11",
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.8.3"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "arrayvec 0.5.2",
  "futures 0.3.8",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -6085,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -6137,7 +6137,7 @@ dependencies = [
 [[package]]
 name = "polkadot-validation"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "futures 0.3.8",
  "log",
@@ -6847,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7088,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "atty",
  "chrono",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "fnv",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7238,7 +7238,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -7249,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "fork-tree",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.8",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.11",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7390,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "sc-client-api",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "lazy_static",
@@ -7433,7 +7433,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "parity-scale-codec",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "finality-grandpa",
@@ -7519,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "finality-grandpa",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.8",
@@ -7561,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -7581,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7600,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -7654,7 +7654,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "libp2p",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.8",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core 15.1.0",
@@ -7794,7 +7794,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "directories 3.0.1",
  "exit-future 0.2.0",
@@ -7858,7 +7858,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7873,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client 15.1.0",
@@ -7893,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "ansi_term 0.12.1",
  "erased-serde",
@@ -7938,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.8",
@@ -7960,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-diagnose",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "sp-core",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8456,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -8468,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.14",
@@ -8493,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "log",
@@ -8546,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8615,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -8689,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8802,7 +8802,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "backtrace",
 ]
@@ -8831,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "serde",
  "sp-core",
@@ -8840,7 +8840,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "hash-db",
  "log",
@@ -8943,12 +8943,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "sp-core",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8988,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.8",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "futures-core",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9188,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "platforms",
 ]
@@ -9196,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.8",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "async-std",
  "derive_more 0.99.11",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.1.30",
  "futures 0.3.8",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "cfg-if 0.1.10",
  "frame-executive",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -9323,8 +9323,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79091baab813855ddf65b191de9fe53e656b6b67c1e9bd23fdcbff8788164684"
+source = "git+https://github.com/paritytech/substrate#39278096356942a087213b0f21c976ac100cb8f8"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -9339,7 +9338,8 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#39278096356942a087213b0f21c976ac100cb8f8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79091baab813855ddf65b191de9fe53e656b6b67c1e9bd23fdcbff8788164684"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -10538,7 +10538,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.8.26"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.8.22"
-source = "git+https://github.com/paritytech/polkadot?branch=master#d72570266223d2ace38a777cad785b63b7fc485b"
+source = "git+https://github.com/paritytech/polkadot#d72570266223d2ace38a777cad785b63b7fc485b"
 dependencies = [
  "parity-scale-codec",
 ]

--- a/launch-notes.md
+++ b/launch-notes.md
@@ -138,7 +138,7 @@ Insert the custom session keys like so in the chain spec. (TODO as I mentioned a
 Finally, bake a raw spec
 
 ```bash
-./polkadot-d7257026-real-overseer build-spec --chain rococo-local-d7257026-real-overseer.json --disable-default-bootnode > rococo-local-d7257026-real-overseer-raw.json
+./polkadot-d7257026-real-overseer build-spec --chain rococo-local-d7257026-real-overseer.json --disable-default-bootnode --raw > rococo-local-d7257026-real-overseer-raw.json
 ```
 
 ## Validator Commands

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2020-10-03"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-10-03
+[toolchain]
+channel = "nightly-2020-10-03"
+components = [ "rustfmt", "clippy" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2020-10-03"
-components = [ "rustfmt" ]
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,1 @@
-[toolchain]
-channel = "nightly-2020-10-03"
-components = ["rustfmt", "clippy"]
+nightly-2020-10-03

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -16,7 +16,8 @@ fi
 if [ -z $CI_PROJECT_NAME ] ; then
   rustup update $WASM_BUILD_TOOLCHAIN
   rustup update stable
-  rustup component add clippy
 fi
+
+rustup component add clippy
 
 rustup target add wasm32-unknown-unknown --toolchain $WASM_BUILD_TOOLCHAIN

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,6 +5,8 @@ source $HOME/.cargo/env
 
 echo "*** Initializing WASM build environment"
 
+# TODO: 'rust-toolchain' is allowed to be a TOML file:
+# https://github.com/rust-lang/rustup/blob/master/doc/src/overrides.md#the-toolchain-file
 RUST_NIGHTLY_VERSION=$(cat rust-toolchain)
 
 if [ -z ${WASM_BUILD_TOOLCHAIN+x} ]; then
@@ -14,6 +16,7 @@ fi
 if [ -z $CI_PROJECT_NAME ] ; then
   rustup update $WASM_BUILD_TOOLCHAIN
   rustup update stable
+  rustup component add clippy
 fi
 
 rustup target add wasm32-unknown-unknown --toolchain $WASM_BUILD_TOOLCHAIN


### PR DESCRIPTION
Testing this on my own fork before creating an upstream PR....

This gnarly set of commits attempts to run `clippy` on the Moonbeam codebase via a github action.

At present, there are a couple issues:

- toolchain download is specified in `rust-toolchain` (a file), which is allowed to be a TOML file and specify additional components to include. As a TOML file specifying `components = [ "clippy" ]`, it appears to properly pull `clippy` in, but then `scripts/init.sh` wants the file to contain nothing but the version string of rust.
- clippy does intelligent things on my own local machine, but it runs off into the `.cargo` directory in CI, producing errors on upstream packages.