### PR TITLE
DO NOT MERGE Nth attempt at migration test mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6265,6 +6265,7 @@ dependencies = [
 name = "pallet-migrations"
 version = "0.1.0"
 dependencies = [
+ "environmental",
  "frame-support",
  "frame-system",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,7 +6269,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "once_cell 1.8.0",
  "parity-scale-codec",
  "sp-core",
  "sp-io",

--- a/pallets/migrations/Cargo.toml
+++ b/pallets/migrations/Cargo.toml
@@ -17,7 +17,6 @@ environmental = "1.1.0"
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.4", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.4", default-features = false }
-once_cell = "1.8.0"
 
 [features]
 default = ["std"]

--- a/pallets/migrations/Cargo.toml
+++ b/pallets/migrations/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.4", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.4", default-features = false }
 parity-scale-codec = { version = "2.0.0", default-features = false }
+environmental = "1.1.0"
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.4", default-features = false }

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -80,6 +80,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		// e.g. runtime upgrade started, completed, etc.
 		RuntimeUpgradeStarted(),
+		RuntimeUpgradeStepped(),
 		RuntimeUpgradeCompleted(),
 		MigrationStarted(Vec<u8>),
 		MigrationProgress(Vec<u8>, Perbill),
@@ -106,6 +107,22 @@ pub mod pallet {
 			weight += process_runtime_upgrades::<T>();
 
 			weight.into()
+		}
+
+		/// on_initialize implementation. Calls process_runtime_upgrades() if we are still in the
+		/// middle of a runtime upgrade.
+		/// TODO: use on_idle or some other hook?
+		fn on_initialize(_: T::BlockNumber) -> Weight {
+
+			// TODO: should account for the minimum one DB read
+			let mut weight: Weight = 0u64.into();
+
+			if ! <FullyUpgraded<T>>::get() {
+				Self::deposit_event(Event::RuntimeUpgradeStepped());
+				weight += process_runtime_upgrades::<T>();
+			}
+
+			weight
 		}
 	}
 

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -29,6 +29,10 @@ use sp_runtime::Perbill;
 
 pub use pallet::*;
 
+// TODO: compile error if this is in mock.rs:
+// "an `extern crate` loading macros must be at the crate root"
+#[macro_use] extern crate environmental;
+
 /// A Migration that must happen on-chain upon a runtime-upgrade
 pub trait Migration {
 	/// A human-readable name for this migration. Also used as storage key.

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -111,7 +111,11 @@ impl MockMigrationManager {
 	}
 
 	fn generate_migrations_list(&self) -> Vec<Box<dyn Migration>> {
-		panic!("FIXME");
+		let mut migrations: Vec<Box<dyn Migration>> = Vec::new();
+		for i in 0..self.name_fn_callbacks.len() {
+			migrations.push(Box::new(MockMigration{index: i}));
+		}
+		migrations
 	}
 }
 

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -80,38 +80,35 @@ impl frame_system::Config for Test {
 	type OnSetCode = ();
 }
 
-type MigrationNameFn<'test> = dyn FnMut() -> &'static str + Send + Sync + 'test;
-type MigrationStepFn<'test> = dyn FnMut(Perbill, Weight) -> (Perbill, Weight) + Send + Sync + 'test;
+type MigrationNameFn = dyn FnMut() -> &'static str;
+type MigrationStepFn = dyn FnMut(Perbill, Weight) -> (Perbill, Weight);
 
 #[derive(Default)]
 pub struct MockMigrationManager<'test> {
-	name_fn_callbacks: Vec<Arc<Mutex<&'test mut MigrationNameFn<'test>>>>,
-	step_fn_callbacks: Vec<Arc<Mutex<&'test mut MigrationStepFn<'test>>>>,
+	// name_fn_callbacks: Vec<&'test mut MigrationNameFn>,
+	// step_fn_callbacks: Vec<&'test mut MigrationStepFn>,
+	name_fn_callbacks: Vec<Box<dyn 'test + FnMut() -> &'static str>>,
+	step_fn_callbacks: Vec<Box<dyn 'test + FnMut(Perbill, Weight) -> (Perbill, Weight)>>,
 }
 
 impl<'test> MockMigrationManager<'test> {
-	pub fn registerCallback<FN, FS>(&'test mut self, name_fn: &'test mut FN, step_fn: &'test mut FS)
+	pub fn registerCallback<FN, FS>(&mut self, name_fn: FN, step_fn: FS)
 	where
-		FN: 'test + FnMut() -> &'static str + Send + Sync,
-		FS: 'test + FnMut(Perbill, Weight) -> (Perbill, Weight) + Send + Sync,
+		FN: 'test + FnMut() -> &'static str,
+		FS: 'test + FnMut(Perbill, Weight) -> (Perbill, Weight),
 	{
-		self.name_fn_callbacks.push(Arc::new(Mutex::new(name_fn)));
-		self.step_fn_callbacks.push(Arc::new(Mutex::new(step_fn)));
+		self.name_fn_callbacks.push(Box::new(name_fn));
+		self.step_fn_callbacks.push(Box::new(step_fn));
 	}
 
-	fn invoke_name_fn(&mut self, index: usize) -> &'static str {
-		// MigrationNameFn returns a String, we need a &str
-		let arc = self.name_fn_callbacks[index].clone();
-		let mut f = arc.lock().unwrap();
-		f()
+	pub(crate) fn invoke_name_fn(&mut self, index: usize) -> &'static str {
+		self.name_fn_callbacks[index]()
 	}
 
-	fn invoke_step_fn(&mut self, index: usize, previous_progress: Perbill, available_weight: Weight)
+	pub(crate) fn invoke_step_fn(&mut self, index: usize, previous_progress: Perbill, available_weight: Weight)
 		-> (Perbill, Weight)
 	{
-		let arc = self.step_fn_callbacks[index].clone();
-		let mut f = arc.lock().unwrap();
-		f(previous_progress, available_weight)
+		self.step_fn_callbacks[index](previous_progress, available_weight)
 	}
 
 	fn generate_migrations_list(&self) -> Vec<Box<dyn Migration>> {
@@ -122,6 +119,7 @@ impl<'test> MockMigrationManager<'test> {
 		migrations
 	}
 }
+// environmental!(MOCK_MIGRATIONS_LIST: MockMigrationManager<'static>);
 
 #[derive(Clone)]
 pub struct MockMigration {
@@ -130,22 +128,23 @@ pub struct MockMigration {
 
 impl Migration for MockMigration {
 	fn friendly_name(&self) -> &str {
-		MOCK_MIGRATIONS_LIST.lock().unwrap().invoke_name_fn(self.index)
+		panic!("fixme");
+		// MOCK_MIGRATIONS_LIST.lock().unwrap().invoke_name_fn(self.index)
 	}
 	fn step(&self, previous_progress: Perbill, available_weight: Weight) -> (Perbill, Weight) {
-		MOCK_MIGRATIONS_LIST.lock().unwrap()
-			.invoke_step_fn(self.index, previous_progress, available_weight)
+		panic!("fixme");
+		// MOCK_MIGRATIONS_LIST.lock().unwrap()
+			// .invoke_step_fn(self.index, previous_progress, available_weight)
 	}
 }
-
-pub static MOCK_MIGRATIONS_LIST: Lazy<Mutex<MockMigrationManager>> = Lazy::new(|| {
-	Default::default()
-});
 
 pub struct MockMigrations;
 impl Get<Vec<Box<dyn Migration>>> for MockMigrations {
 	fn get() -> Vec<Box<dyn Migration>> {
-		MOCK_MIGRATIONS_LIST.lock().unwrap().generate_migrations_list()
+		let mut migrations: Vec<Box<dyn Migration>> = Vec::new();
+		// MOCK_MIGRATIONS_LIST::with(|m| { migrations = m.generate_migrations_list(); });
+		panic!("fixme");
+		migrations
 	}
 }
 

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -16,7 +16,7 @@
 
 //! Unit testing
 use crate::mock::{
-	events, ExtBuilder, Migrations, System, MockMigration, replace_mock_migrations_list
+	events, ExtBuilder, Migrations, System, MockMigration
 };
 use crate::Event;
 use std::sync::{Arc, Mutex};
@@ -33,6 +33,7 @@ fn genesis_builder_works() {
 	})
 }
 
+/*
 #[test]
 fn mock_migrations_static_hack_works() {
 	let mut flip_me: bool = false;
@@ -52,6 +53,7 @@ fn mock_migrations_static_hack_works() {
 
 	assert_eq!(flip_me, true, "mock migration callback should work with closure");
 }
+*/
 
 #[test]
 fn on_runtime_upgrade_returns() {

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -34,20 +34,23 @@ fn genesis_builder_works() {
 }
 
 #[test]
-fn mock_migrations_static_hack_works() {
+fn mock_migrations_static_hack_works<'test>() {
 	let mut name_fn_called: bool = false;
 	let mut step_fn_called: bool = false;
+
+	let mut mgr: crate::mock::MockMigrationManager = Default::default();
 
 	// works:
 	// let name_fn: &(FnMut() -> &'static str + Send + Sync) = &|| { "hi" };
 
-	crate::mock::MOCK_MIGRATIONS_LIST.lock().unwrap()
+	// crate::mock::MOCK_MIGRATIONS_LIST.lock().unwrap()
+	mgr
 		.registerCallback(
-			&|| {
+			&mut|| {
 				name_fn_called = true;
 				"hello, world"
 			},
-			&|_, _| -> (Perbill, Weight) {
+			&mut|_, _| -> (Perbill, Weight) {
 				step_fn_called = true;
 				(Perbill::zero(), 0u64.into())
 			}

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -33,27 +33,33 @@ fn genesis_builder_works() {
 	})
 }
 
-/*
 #[test]
 fn mock_migrations_static_hack_works() {
-	let mut flip_me: bool = false;
-	replace_mock_migrations_list(&mut vec![
-		MockMigration {
-			name: "test".into(),
-			callback: |_: Perbill, _: Weight| -> (Perbill, Weight) {
-				flip_me = true;
-				(Perbill::one(), 0u64.into())
+	let mut name_fn_called: bool = false;
+	let mut step_fn_called: bool = false;
+
+	// works:
+	// let name_fn: &(FnMut() -> &'static str + Send + Sync) = &|| { "hi" };
+
+	crate::mock::MOCK_MIGRATIONS_LIST.lock().unwrap()
+		.registerCallback(
+			&|| {
+				name_fn_called = true;
+				"hello, world"
+			},
+			&|_, _| -> (Perbill, Weight) {
+				step_fn_called = true;
+				(Perbill::zero(), 0u64.into())
 			}
-		},
-	]);
+		);
 
 	ExtBuilder::default().build().execute_with(|| {
 		Migrations::on_runtime_upgrade();
 	});
 
-	assert_eq!(flip_me, true, "mock migration callback should work with closure");
+	assert_eq!(name_fn_called, true, "mock migration should call friendly_name()");
+	assert_eq!(step_fn_called, true, "mock migration should call step()");
 }
-*/
 
 #[test]
 fn on_runtime_upgrade_returns() {

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -39,28 +39,21 @@ fn mock_migrations_static_hack_works() {
 	let name_fn_called = Arc::new(Mutex::new(false));
 	let step_fn_called = Arc::new(Mutex::new(false));
 
-	println!("Calling execute_with_mock_migrations...");
 	crate::mock::execute_with_mock_migrations(&mut |mgr: &mut MockMigrationManager| {
-		println!("Inside execute_with_mock_migrations");
 		let name_fn_called = Arc::clone(&name_fn_called);
 		let step_fn_called = Arc::clone(&step_fn_called);
 
-		println!("Registering callbacks...");
 		mgr.registerCallback(
 			move || {
-				println!("inside name_fn callback!");
 				*name_fn_called.lock().unwrap() = true;
 				"hello, world"
 			},
 			move |_, _| -> (Perbill, Weight) {
-				println!("inside step_fn callback!");
 				*step_fn_called.lock().unwrap() = true;
-				(Perbill::zero(), 0u64.into())
+				(Perbill::one(), 0u64.into())
 			}
 		);
-		println!("Done registering callbacks.");
 	});
-	println!("Done with execute_with_mock_migrations");
 
 	assert_eq!(*name_fn_called.lock().unwrap(), true, "mock migration should call friendly_name()");
 	assert_eq!(*step_fn_called.lock().unwrap(), true, "mock migration should call step()");
@@ -84,4 +77,34 @@ fn on_runtime_upgrade_emits_events() {
 		];
 		assert_eq!(events(), expected);
 	});
+}
+
+#[test]
+fn step_called_until_done() {
+
+	let num_step_calls = Arc::new(Mutex::new(0usize));
+
+	println!("step_called_until_done()...");
+
+	crate::mock::execute_with_mock_migrations(&mut |mgr: &mut MockMigrationManager| {
+		let num_step_calls = Arc::clone(&num_step_calls);
+
+		mgr.registerCallback(
+			move || {
+				"migration1"
+			},
+			move |_, _| -> (Perbill, Weight) {
+				let mut num_step_calls = num_step_calls.lock().unwrap();
+				println!("step fn called, num times previously: {}", num_step_calls);
+				*num_step_calls += 1;
+				if *num_step_calls == 10 {
+					(Perbill::one(), 0u64.into())
+				} else {
+					(Perbill::zero(), 0u64.into())
+				}
+			}
+		);
+	});
+
+	assert_eq!(*num_step_calls.lock().unwrap(), 10, "migration step should be called until done");
 }


### PR DESCRIPTION
This is my latest attempt at producing a test mock for `pallet_migrations`. I'm posting this here for discussion. It's a steaming pile of hot rust garbage.

## The problem

The original design of the Migrations pallet seems to work (I did a quick proof of concept where I plumbed an actual method invocation through a pallet, so I'm fairly confident in that).

Where things fall apart is in testing. It starts with the `Get` trait, which provides no context (other than potentially being generic over `Runtime`):

```rust
pub trait Get<T> {
    fn get() -> T;
}
```

This essentially requires that a `T` be produced from a static context. In this implementation, `T` is a Vec of `trait object`s:

```rust
type MigrationsList: Get<Vec<Box<dyn Migration>>>;
```

Where Migration is:

```rust
pub trait Migration {
    fn friendly_name(&self) -> &str;
    fn step(&self, previous_progress: Perbill, available_weight: Weight) -> (Perbill, Weight);
}
```

An example of a test case that I would like to support (using a `closure` capturing local stack variables by mutable reference):

```rust
#[test]
fn mock_migrations_static_hack_works() {
    let mut name_fn_called: bool = false;
    let mut step_fn_called: bool = false;

    // these closures map directly to the Migration trait fns
    something.registerCallback(
            &mut|| {
                name_fn_called = true;
                "hello, world"
            },
            &mut|_, _| -> (Perbill, Weight) {
                step_fn_called = true;
                (Perbill::zero(), 0u64.into())
            }
        );

    ExtBuilder::default().build().execute_with(|| {
        // this would:
        // 1) call our Get impl
        // 2) iterate over each trait object implementing Migration
        // 3) invoke the methods of each, effectively invoking our closures above
        Migrations::on_runtime_upgrade();
    });

    assert_eq!(name_fn_called, true, "mock migration should call friendly_name()");
    assert_eq!(step_fn_called, true, "mock migration should call step()");
}
```

There are a lot of pieces to this that complicated things, but the implied `'static` lifetime of using a singleton is the one that just doesn't play well with `FnMut`/closures. I don't think there's a way around this without bigger architectural changes (or maybe using `unsafe`).

Basically, the entire mock design mess boils down to this:
* I want a singleton to satisfy the need for the `Get` impl to provide a Vec with nothing but static context
* Each test would then create a list of closures (`FnMut`) that could be associated ("glued") with the Vec's contents
* When `pallet_migration` invokes a `Migration` callback, the singleton could look up the proper closure and invoke it